### PR TITLE
Allow setting custom user-agent in gRPC calls

### DIFF
--- a/packages/grpc-js/README.md
+++ b/packages/grpc-js/README.md
@@ -69,7 +69,7 @@ Many channel arguments supported in `grpc` are not supported in `@grpc/grpc-js`.
   - `channelOverride`
   - `channelFactoryOverride`
 
-  > **Note**: If user-agent is passed in the request metadata, it will take precedence and be used instead of the one set using the `grpc.primary_user_agent` or `grpc.secondary_user_agent` channel options.
+  > **Note**: `user-agent` passed in the request metadata will take precedence over  `grpc.primary_user_agent` and `grpc.secondary_user_agent` channel options.
 
 ## Some Notes on API Guarantees
 

--- a/packages/grpc-js/README.md
+++ b/packages/grpc-js/README.md
@@ -69,6 +69,8 @@ Many channel arguments supported in `grpc` are not supported in `@grpc/grpc-js`.
   - `channelOverride`
   - `channelFactoryOverride`
 
+  > **Note**: If user-agent is passed in the request metadata, it will take precedence and be used instead of the one set using the `grpc.primary_user_agent` or `grpc.secondary_user_agent` channel options.
+
 ## Some Notes on API Guarantees
 
 The public API of this library follows semantic versioning, with some caveats:

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -502,11 +502,14 @@ class Http2Transport implements Transport {
   ): Http2SubchannelCall {
     const headers = metadata.toHttp2Headers();
     headers[HTTP2_HEADER_AUTHORITY] = host;
-    headers[HTTP2_HEADER_USER_AGENT] = this.userAgent;
     headers[HTTP2_HEADER_CONTENT_TYPE] = 'application/grpc';
     headers[HTTP2_HEADER_METHOD] = 'POST';
     headers[HTTP2_HEADER_PATH] = method;
     headers[HTTP2_HEADER_TE] = 'trailers';
+    // Set default 'user-agent' header if it's not explicitly set in the metadata
+    if (!headers[HTTP2_HEADER_USER_AGENT]) {
+      headers[HTTP2_HEADER_USER_AGENT] = this.userAgent;
+    }
     let http2Stream: http2.ClientHttp2Stream;
     /* In theory, if an error is thrown by session.request because session has
      * become unusable (e.g. because it has received a goaway), this subchannel

--- a/packages/grpc-js/src/transport.ts
+++ b/packages/grpc-js/src/transport.ts
@@ -507,7 +507,11 @@ class Http2Transport implements Transport {
     headers[HTTP2_HEADER_PATH] = method;
     headers[HTTP2_HEADER_TE] = 'trailers';
     // Set default 'user-agent' header if it's not explicitly set in the metadata
-    if (!headers[HTTP2_HEADER_USER_AGENT]) {
+    if (
+      !Object.keys(headers).some(
+        key => key.toLowerCase() === HTTP2_HEADER_USER_AGENT
+      )
+    ) {
       headers[HTTP2_HEADER_USER_AGENT] = this.userAgent;
     }
     let http2Stream: http2.ClientHttp2Stream;

--- a/packages/grpc-js/test/test-user-agent.ts
+++ b/packages/grpc-js/test/test-user-agent.ts
@@ -107,8 +107,7 @@ describe('Configuring user-agent via metadata', () => {
 
   it('should honor user-agent via metadata regardless of case', done => {
     const metadata = new CustomMetadata();
-    const userAgentHeader = 'User-Agent';
-    metadata.set(userAgentHeader, 'Custom-User-Agent');
+    metadata.set('User-Agent', 'Custom-User-Agent');
 
     client.echo(
       { value: 'test value', value2: 3 },

--- a/packages/grpc-js/test/test-user-agent.ts
+++ b/packages/grpc-js/test/test-user-agent.ts
@@ -1,0 +1,97 @@
+import * as assert from 'assert';
+import * as http2 from 'http2';
+import * as path from 'path';
+
+import * as grpc from '../src';
+import { Server, ServerCredentials } from '../src';
+import { ServiceClient, ServiceClientConstructor } from '../src/make-client';
+import { sendUnaryData, ServerUnaryCall } from '../src/server-call';
+
+import { loadProtoFile } from './common';
+import { Response__Output } from './generated/Response';
+import * as Package from '../package.json';
+
+const { HTTP2_HEADER_USER_AGENT } = http2.constants;
+const clientVersion = Package.version;
+
+describe('Handling of user-agent in gRPC Requests', () => {
+  let server: Server;
+  let client: ServiceClient;
+  let lastCallMetadata: grpc.Metadata; // Store the metadata from the last call
+
+  const protoFile = path.join(__dirname, 'fixtures', 'echo_service.proto');
+  const echoService = loadProtoFile(protoFile)
+    .EchoService as ServiceClientConstructor;
+
+  const serviceImplementation = {
+    echo(call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) {
+      lastCallMetadata = call.metadata;
+      callback(null, call.request);
+    },
+  };
+
+  before(done => {
+    server = new Server();
+    server.addService(echoService.service, serviceImplementation);
+
+    server.bindAsync(
+      'localhost:0',
+      ServerCredentials.createInsecure(),
+      (err, port) => {
+        assert.ifError(err);
+        client = new echoService(
+          `localhost:${port}`,
+          grpc.credentials.createInsecure()
+        );
+        server.start();
+        done();
+      }
+    );
+  });
+
+  after(done => {
+    client.close();
+    server.tryShutdown(done);
+  });
+
+  it('should set default user-agent if not set in metadata', done => {
+    const metadata = new grpc.Metadata();
+
+    client.echo(
+      { value: 'test value', value2: 3 },
+      metadata,
+      (err: grpc.ServiceError, response: Response__Output) => {
+        if (err) {
+          done(err);
+        } else {
+          assert.strictEqual(
+            lastCallMetadata.get(HTTP2_HEADER_USER_AGENT)[0],
+            `grpc-node-js/${clientVersion}`
+          );
+          done();
+        }
+      }
+    );
+  });
+
+  it('should not override user-agent if set in metadata', done => {
+    const metadata = new grpc.Metadata();
+    metadata.set(HTTP2_HEADER_USER_AGENT, 'custom-user-agent');
+
+    client.echo(
+      { value: 'test value', value2: 3 },
+      metadata,
+      (err: grpc.ServiceError, response: Response) => {
+        if (err) {
+          done(err);
+        } else {
+          assert.strictEqual(
+            lastCallMetadata.get(HTTP2_HEADER_USER_AGENT)[0],
+            'custom-user-agent'
+          );
+          done();
+        }
+      }
+    );
+  });
+});


### PR DESCRIPTION
Problem: Currently, the grpc-js library automatically sets a default 'user-agent' header in gRPC calls, limiting flexibility for users who need to identify their clients with specific user-agent information.

Solution: This change introduces the ability to set a custom user-agent header for gRPC calls. Modifications were made to allow custom user-agent strings if they are explicitly provided in the call metadata.